### PR TITLE
Change from include_tasks to import_tasks for static includes of tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,18 +1,18 @@
 ---
 
-- include_tasks: download_install.yml
+- import_tasks: download_install.yml
   tags:
     - cantaloupe-install
 
-- include_tasks: setup.yml
+- import_tasks: setup.yml
   tags:
     - cantaloupe-setup
 
-- include_tasks: configure.yml
+- import_tasks: configure.yml
   tags:
     - cantaloupe-config
 
-- include_tasks: configure_delegate.yml
+- import_tasks: configure_delegate.yml
   tags:
     - cantaloupe-delegate
   when: cantaloupe_delegate_script_enabled == "true"


### PR DESCRIPTION
The` include_tasks ` statement is a **dynamic** include of tasks, while `import_tasks ` is a **static** include of tasks. 

In order to the tags to be inherited down into the included tasks, it is necessary to use a static include.